### PR TITLE
chore: add basic ci for bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,4 +2,6 @@
 common --enable_bzlmod
 build --bes_results_url=https://app.buildbuddy.io/invocation/
 build --bes_backend=grpcs://remote.buildbuddy.io
+build --remote_timeout=10m
+build --remote_executor=grpcs://remote.buildbuddy.io
 build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
 # Enable Bzlmod for every Bazel command
 common --enable_bzlmod
+build --bes_results_url=https://app.buildbuddy.io/invocation/
+build --bes_backend=grpcs://remote.buildbuddy.io
+build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Setup Bazel
-        uses: bazelbuild/setup-bazel@v4
-        with:
-          bazelisk-cache: true
+      - name: Setup Bazelisk (Bazel version manager)
+        uses: bazelbuild/setup-bazelisk@v1
 
       - name: Restore Bazel Cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
 
       - name: Restore Bazel Cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
           path: ${{ steps.bazel-path.outputs.path }}
-          key: bazel-${{ runner.os }}-${{ github.sha }}
+          key: bazel-${{ runner.os }}-${{ hashFiles('WORKSPACE', '**/BUILD', '**/*.bzl') }}
           restore-keys: |
             bazel-${{ runner.os }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
           key: bazel-${{ runner.os }}-${{ hashFiles('WORKSPACE', '**/BUILD', '**/*.bzl') }}
           restore-keys: |
             bazel-${{ runner.os }}-
+      - name: Debug Cache Key and Path
+        run: |
+          echo "Cache path: ${{ steps.bazel-path.outputs.path }}"
+          echo "Cache key: bazel-${{ runner.os }}-${{ hashFiles('WORKSPACE', '**/BUILD', '**/*.bzl') }}"
 
       - name: Inject BuildBuddy Remote Cache Key (if set)
         if: env.BUILDBUDDY_API_KEY != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Ensure Cache Path Exists
+        run: |
+          mkdir -p ~/.cache/bazel
+
       - name: Setup Bazelisk (Bazel version manager)
         uses: bazelbuild/setup-bazelisk@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Setup Bazelisk (Bazel version manager)
         uses: bazelbuild/setup-bazelisk@v1
 
+      - name: Ensure Cache Path Exists
+        run: |
+          mkdir -p ~/.cache/bazel
+
       - name: Restore Bazel Cache
         uses: actions/cache@v4
         with:
@@ -26,6 +30,11 @@ jobs:
           key: bazel-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             bazel-${{ runner.os }}-
+
+      - name: Debug Cache
+        run: |
+          echo "Cache key: bazel-${{ runner.os }}-${{ github.sha }}"
+          ls -la ~/.cache/bazel || echo "Cache directory does not exist or is empty."
 
       - name: Determine changed targets
         id: changes
@@ -45,4 +54,8 @@ jobs:
       - name: Upload Test Logs on Failure
         if: failure()
         run: |
-          find bazel-testlogs -name "test.log" -exec cat {} \;
+          if [ -d bazel-testlogs ]; then
+            find bazel-testlogs -name "test.log" -exec cat {} \;
+          else
+            echo "No test logs to upload."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
   bazel:
     name: Bazel Build & Test
     runs-on: ubuntu-latest
-
+    env:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -39,8 +40,8 @@ jobs:
       - name: Determine changed targets
         id: changes
         run: |
-          echo "CHANGED=$(bazel query 'kind(".*", rdeps(//..., set($(git diff --name-only origin/main | sed "s|^|//|" | paste -sd " " -))))' || echo '')" >> $GITHUB_ENV
-
+          CHANGED_FILES=$(git diff --name-only origin/main | sed 's|^|//|' | paste -sd ' ')
+          echo "CHANGED=$(bazel query \"kind('.*', rdeps(//..., set($CHANGED_FILES)))\" || echo '')" >> $GITHUB_ENV
       - name: Build Changed Targets
         if: env.CHANGED != ''
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,30 +17,22 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Ensure Cache Path Exists
+      - name: Install Bazelisk Manually
         run: |
-          mkdir -p ~/.cache/bazel
+          echo "Installing Bazelisk..."
+          curl -sSL https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64 -o /tmp/bazelisk
+          chmod +x /tmp/bazelisk
+          mv /tmp/bazelisk /usr/local/bin/bazelisk
+          bazelisk version
 
-      - name: Setup Bazelisk (Bazel version manager)
-        uses: bazelbuild/setup-bazelisk@v1
-
-      - name: Get Bazel Output Base Path
-        id: bazel-path
+      - name: Get Bazel output paths
+        id: bazel-paths
         run: |
-          echo "path=$(bazel info output_base)" >> "$GITHUB_OUTPUT"
+          echo "bin=$(bazel info bazel-bin)" >> "$GITHUB_OUTPUT"
+          echo "out=$(bazel info output_path)" >> "$GITHUB_OUTPUT"
+          echo "testlogs=$(bazel info bazel-testlogs)" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Bazel Cache
-        uses: actions/cache@v4
-        continue-on-error: true
-        with:
-          path: ${{ steps.bazel-path.outputs.path }}
-          key: bazel-${{ runner.os }}-${{ hashFiles('WORKSPACE', '**/BUILD', '**/*.bzl') }}
-          restore-keys: |
-            bazel-${{ runner.os }}-
-      - name: Debug Cache Key and Path
-        run: |
-          echo "Cache path: ${{ steps.bazel-path.outputs.path }}"
-          echo "Cache key: bazel-${{ runner.os }}-${{ hashFiles('WORKSPACE', '**/BUILD', '**/*.bzl') }}"
+      # Removed Cache Step
 
       - name: Inject BuildBuddy Remote Cache Key (if set)
         if: env.BUILDBUDDY_API_KEY != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -19,44 +20,55 @@ jobs:
       - name: Setup Bazelisk (Bazel version manager)
         uses: bazelbuild/setup-bazelisk@v1
 
-      - name: Ensure Cache Path Exists
+      - name: Get Bazel Output Base Path
+        id: bazel-path
         run: |
-          mkdir -p ~/.cache/bazel
+          echo "path=$(bazel info output_base)" >> "$GITHUB_OUTPUT"
 
       - name: Restore Bazel Cache
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/bazel
+          path: ${{ steps.bazel-path.outputs.path }}
           key: bazel-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             bazel-${{ runner.os }}-
 
-      - name: Debug Cache
-        run: |
-          echo "Cache key: bazel-${{ runner.os }}-${{ github.sha }}"
-          ls -la ~/.cache/bazel || echo "Cache directory does not exist or is empty."
+      - name: Inject BuildBuddy Remote Cache Key (if set)
+        if: env.BUILDBUDDY_API_KEY != ''
+        run: echo "build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> .bazelrc
 
       - name: Determine changed targets
         id: changes
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/main | sed 's|^|//|' | paste -sd ' ')
-          echo "CHANGED=$(bazel query \"kind('.*', rdeps(//..., set($CHANGED_FILES)))\" || echo '')" >> $GITHUB_ENV
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD | sed 's|^|//|' | paste -sd ' ')
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No changed files."
+            echo "CHANGED=" >> $GITHUB_ENV
+            exit 0
+          fi
+
+          echo "Changed files: $CHANGED_FILES"
+          CHANGED_TARGETS=$(bazel query "kind('.*', rdeps(//..., set($CHANGED_FILES)))" || echo "")
+          echo "CHANGED=$CHANGED_TARGETS" >> $GITHUB_ENV
+
       - name: Build Changed Targets
         if: env.CHANGED != ''
         run: |
+          echo "Building changed targets..."
           bazel build $CHANGED
 
       - name: Test Changed Targets
         if: env.CHANGED != ''
         run: |
+          echo "Testing changed targets..."
           bazel test $CHANGED --test_output=errors
 
       - name: Upload Test Logs on Failure
         if: failure()
         run: |
           if [ -d bazel-testlogs ]; then
-            find bazel-testlogs -name "test.log" -exec cat {} \;
+            echo "Dumping failed test logs:"
+            find bazel-testlogs -name "test.log" -exec echo "::group::{}" \; -exec cat {} \; -exec echo "::endgroup::" \;
           else
             echo "No test logs to upload."
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Bazel CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  bazel:
+    name: Bazel Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Bazel
+        uses: bazelbuild/setup-bazel@v4
+        with:
+          bazelisk-cache: true
+
+      - name: Restore Bazel Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/bazel
+          key: bazel-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            bazel-${{ runner.os }}-
+
+      - name: Determine changed targets
+        id: changes
+        run: |
+          echo "CHANGED=$(bazel query 'kind(".*", rdeps(//..., set($(git diff --name-only origin/main | sed "s|^|//|" | paste -sd " " -))))' || echo '')" >> $GITHUB_ENV
+
+      - name: Build Changed Targets
+        if: env.CHANGED != ''
+        run: |
+          bazel build $CHANGED
+
+      - name: Test Changed Targets
+        if: env.CHANGED != ''
+        run: |
+          bazel test $CHANGED --test_output=errors
+
+      - name: Upload Test Logs on Failure
+        if: failure()
+        run: |
+          find bazel-testlogs -name "test.log" -exec cat {} \;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced an automated CI workflow to build and test only impacted Bazel targets on pushes and pull requests to the main branch.
	- Enhanced Bazel configuration to support remote build event reporting and authentication with a specified backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->